### PR TITLE
[FEATURE] : Reworked linter outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Editors
+.vscode
+.idea

--- a/poetry.lock
+++ b/poetry.lock
@@ -177,14 +177,14 @@ gitdb = ">=4.0.1,<5"
 
 [[package]]
 name = "identify"
-version = "2.5.12"
+version = "2.5.13"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.12-py2.py3-none-any.whl", hash = "sha256:e8a400c3062d980243d27ce10455a52832205649bbcaf27ffddb3dfaaf477bad"},
-    {file = "identify-2.5.12.tar.gz", hash = "sha256:0bc96b09c838310b6fcfcc61f78a981ea07f94836ef6ef553da5bb5d4745d662"},
+    {file = "identify-2.5.13-py2.py3-none-any.whl", hash = "sha256:8aa48ce56e38c28b6faa9f261075dea0a942dfbb42b341b4e711896cbb40f3f7"},
+    {file = "identify-2.5.13.tar.gz", hash = "sha256:abb546bca6f470228785338a01b539de8a85bbf46491250ae03363956d8ebb10"},
 ]
 
 [package.extras]
@@ -505,14 +505,14 @@ testutils = ["gitpython (>3)"]
 
 [[package]]
 name = "pytest"
-version = "7.2.0"
+version = "7.2.1"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pytest-7.2.0-py3-none-any.whl", hash = "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71"},
-    {file = "pytest-7.2.0.tar.gz", hash = "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"},
+    {file = "pytest-7.2.1-py3-none-any.whl", hash = "sha256:c7c6ca206e93355074ae32f7403e8ea12163b1163c976fee7d4d84027c162be5"},
+    {file = "pytest-7.2.1.tar.gz", hash = "sha256:d45e0952f3727241918b8fd0f376f5ff6b301cc0777c6f9a556935c92d8a7d42"},
 ]
 
 [package.dependencies]
@@ -600,18 +600,18 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "65.6.3"
+version = "66.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-65.6.3-py3-none-any.whl", hash = "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54"},
-    {file = "setuptools-65.6.3.tar.gz", hash = "sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75"},
+    {file = "setuptools-66.0.0-py3-none-any.whl", hash = "sha256:a78d01d1e2c175c474884671dde039962c9d74c7223db7369771fcf6e29ceeab"},
+    {file = "setuptools-66.0.0.tar.gz", hash = "sha256:bd6eb2d6722568de6d14b87c44a96fac54b2a45ff5e940e639979a3d1792adb6"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,20 +8,20 @@ packages = [{ include = "src" }]
 
 [tool.poe.tasks]
 _pylint.cmd = "pylint ${files}"
-_pylint.args = [{ name = "files", default = "src", positional = true }]
+_pylint.args = [{ name = "files", default = "src", positional = true, multiple = true }]
 
 _mypy.cmd = "mypy ${files}"
-_mypy.args = [{ name = "files", default = "src", positional = true }]
+_mypy.args = [{ name = "files", default = "src", positional = true, multiple = true }]
 
 _bandit.cmd = "bandit -c pyproject.toml -r ${files}"
-_bandit.args = [{ name = "files", default = "src", positional = true }]
+_bandit.args = [{ name = "files", default = "src", positional = true, multiple = true }]
 
 lint.sequence = [
     { ref = "_mypy ${files}" },
     { ref = "_pylint ${files}" },
     { ref = "_bandit ${files}" }
 ]
-lint.args = [{ name = "files", positional = true }]
+lint.args = [{ name = "files", positional = true, multiple = true }]
 lint.ignore_fail = "return_zero"
 
 test = "pytest test/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,16 +2,26 @@
 name = "name"
 version = "0.1.0"
 description = ""
-authors = [""]
+authors = []
 readme = "README.md"
-packages = [{include = "src"}]
+packages = [{ include = "src" }]
 
 [tool.poe.tasks]
+_pylint.cmd = "pylint ${files}"
+_pylint.args = [{ name = "files", default = "src", positional = true }]
+
+_mypy.cmd = "mypy ${files}"
+_mypy.args = [{ name = "files", default = "src", positional = true }]
+
+_bandit.cmd = "bandit -c pyproject.toml -r ${files}"
+_bandit.args = [{ name = "files", default = "src", positional = true }]
+
 lint.sequence = [
-    {cmd = "mypy ./src/**/*.py"},
-    {cmd = "pylint src"},
-    {cmd = "bandit -c pyproject.toml -r src/"}
+    { ref = "_mypy ${files}" },
+    { ref = "_pylint ${files}" },
+    { ref = "_bandit ${files}" }
 ]
+lint.args = [{ name = "files", positional = true }]
 lint.ignore_fail = "return_zero"
 
 test = "pytest test/"
@@ -27,7 +37,7 @@ pre-commit = "^2.20.0"
 mypy = "^0.991"
 poethepoet = "^0.17.1"
 pylint = "^2.15.10"
-bandit = {extras = ["toml"], version = "^1.7.4"}
+bandit = { extras = ["toml"], version = "^1.7.4" }
 pytest = "^7.2.0"
 pytest-benchmark = "^4.0.0"
 
@@ -61,7 +71,7 @@ show_column_numbers = true
 strict_concatenate = true
 
 [tool.bandit]
-tests = ["B402","B401","B310","B403","B404","B302","B321","B301","B312","B303","B306","B304","B305","B308","B307","B313","B320","B405","B409","B408","B407","B406","B410","B411","B101","B102","B201","B104","B107","B106","B105","B608","B108","B701","B609","B601","B501","B103","B507","B502","B504","B605","B606","B607","B602","B603","B112","B110","B702","B505","B506", "B323", "B610", "B703", "B611", "B412","B413"]
+tests = ["B402", "B401", "B310", "B403", "B404", "B302", "B321", "B301", "B312", "B303", "B306", "B304", "B305", "B308", "B307", "B313", "B320", "B405", "B409", "B408", "B407", "B406", "B410", "B411", "B101", "B102", "B201", "B104", "B107", "B106", "B105", "B608", "B108", "B701", "B609", "B601", "B501", "B103", "B507", "B502", "B504", "B605", "B606", "B607", "B602", "B603", "B112", "B110", "B702", "B505", "B506", "B323", "B610", "B703", "B611", "B412", "B413"]
 exclude_dirs = ["./test/*"]
 
 [tool.pylint.main]


### PR DESCRIPTION
## 1) Description

Added arguments to linter to check only certain files. This is useful to check only PR changes.

## 2) Technical choice

I added _private_ sub-command for each linter as this is the only way to add arguments in a _cmd_ sequence.
See https://github.com/nat-n/poethepoet#declaring-cli-arguments.

This might also be useful at some point to only start one linter.

## 3) Checks

- [x] My code follows the contributing guidelines
- [x] I have read the code of conduct
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes